### PR TITLE
feat(validator): blend VHFT (Synth Ultra) as a 4th competition

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -45,6 +45,7 @@ from synth.validator.bigtable_prediction_storage import (
 )
 from synth.validator.miner_data_handler import MinerDataHandler
 from synth.validator.prediction_notifier import PredictionNotifier
+from synth.validator.vhft_score_provider import VhftScoreProvider
 from synth.validator.price_data_provider import PriceDataProvider
 from synth.validator.storage_backend import STORAGE_BACKEND_BIGTABLE
 from synth.validator import competition_config
@@ -94,6 +95,9 @@ class Validator(BaseValidatorNeuron):
         # None (disabled) unless both PUBSUB_PROJECT and
         # PUBSUB_TOPIC_PREDICTIONS are set.
         self.prediction_notifier = PredictionNotifier.from_env()
+        # None (disabled) unless VHFT_SCORES_URL is set — when enabled, blends the
+        # VHFT 10s competition into set_weights as a 4th competition.
+        self.vhft_score_provider = VhftScoreProvider.from_env()
         self.miner_data_handler = MinerDataHandler(
             bigtable_storage=bigtable_storage
         )
@@ -331,6 +335,7 @@ class Validator(BaseValidatorNeuron):
         moving_averages_data = calculate_moving_average_and_update_rewards(
             miner_data_handler=self.miner_data_handler,
             scored_time=scored_time,
+            vhft_provider=self.vhft_score_provider,
         )
 
         if len(moving_averages_data) == 0:

--- a/synth/validator/competition_config.py
+++ b/synth/validator/competition_config.py
@@ -120,10 +120,16 @@ VHFT_COMPETITION = CompetitionConfig(
     # window_days is nominal — the external scorer already windows the scores, so
     # no per-window aggregation happens here.
     window_days=1,
-    # softmax_beta = -0.25 for the mean_crps scale (steeper than the 24h comps'
-    # -0.15, gentler than Crypto-1h's -0.3). MUST stay negative (lower CRPS =
-    # higher reward), same convention as the other competitions.
-    softmax_beta=-0.25,
+    # softmax_beta = -2.0 (was -0.25) — steeper than every other competition by
+    # design, not scale-matched to them. The softmax acts on ABSOLUTE mean_crps and
+    # the field is tightly bunched, so beta converts a small CRPS gap into a large
+    # weight gap: measured on the 2026-08-25 field (spread 6.537-7.207, ~10% of the
+    # ~6.9 base), -0.25 gave a 1.18x best/worst ratio and a 31.6% top-3 share,
+    # -2.0 gives 3.82x and 43.0%. The flip side is reward variance — rank shuffle
+    # inside that narrow band now moves weight substantially.
+    # MUST stay negative (lower CRPS = higher reward), same convention as the
+    # other competitions.
+    softmax_beta=-2.0,
 )
 
 # Plausible size of the VHFT participant field, enforced in

--- a/synth/validator/competition_config.py
+++ b/synth/validator/competition_config.py
@@ -125,3 +125,18 @@ VHFT_COMPETITION = CompetitionConfig(
     # higher reward), same convention as the other competitions.
     softmax_beta=-0.25,
 )
+
+# Plausible size of the VHFT participant field, enforced in
+# compute_vhft_smoothed_score — outside this range the blend is skipped for the
+# cycle rather than trusted.
+#
+# The VHFT block is a fixed SMOOTHED_SCORE_COEFFICIENT however many uids share
+# it, so each participant's cut scales as 1/N: at 9 participants the top uid
+# takes ~2.8% of all emissions, at 3 it takes ~8.3%, and at 1 it takes the whole
+# 25%. A round that scores only a handful of miners — a degraded scorer, or a
+# field that has mostly dropped out — would otherwise quietly hand one miner an
+# outsized share, so require a floor. The ceiling is the other end of the same
+# argument: a snapshot naming dozens of scored participants is a malfunctioning
+# scorer rather than a competition that suddenly got popular.
+VHFT_MIN_PARTICIPANTS = 3
+VHFT_MAX_PARTICIPANTS = 64

--- a/synth/validator/competition_config.py
+++ b/synth/validator/competition_config.py
@@ -121,13 +121,20 @@ VHFT_COMPETITION = CompetitionConfig(
     # no per-window aggregation happens here.
     window_days=1,
     # softmax_beta = -2.0 (was -0.25) — steeper than every other competition by
-    # design, not scale-matched to them. The softmax acts on ABSOLUTE mean_crps and
-    # the field is tightly bunched, so beta converts a small CRPS gap into a large
-    # weight gap: measured on the 2026-08-25 field (spread 6.537-7.207, ~10% of the
-    # ~6.9 base), -0.25 gave a 1.18x best/worst ratio and a 31.6% top-3 share,
-    # -2.0 gives 3.82x and 43.0%. The flip side is reward variance — rank shuffle
-    # inside that narrow band now moves weight substantially.
-    # MUST stay negative (lower CRPS = higher reward), same convention as the
+    # design, not scale-matched to them. MEASURED on a real 3h window (2026-08-27,
+    # 11 miners, after the scorer moved to the subnet-parity pipeline): the field
+    # spans 1.186 and -2.0 gives a 10.7x best/worst ratio with a 45% top-3 share,
+    # against 1.19x at -0.15 and 1.43x at -0.3.
+    #
+    # What beta actually responds to is the SPREAD between miners, NOT the absolute
+    # score level: the scorer now subtracts each prompt's winner, and softmax is
+    # invariant to that shared offset, so shifting every score changes nothing. A
+    # widening field therefore concentrates rewards harder at a fixed beta — the
+    # spread doubled between 2026-08-25 and -26 and the ratio moved with it. Revisit
+    # this number if the spread moves materially; re-measure, do not reason from the
+    # score level.
+    #
+    # MUST stay negative (lower score = higher reward), same convention as the
     # other competitions.
     softmax_beta=-2.0,
 )

--- a/synth/validator/competition_config.py
+++ b/synth/validator/competition_config.py
@@ -120,23 +120,19 @@ VHFT_COMPETITION = CompetitionConfig(
     # window_days is nominal — the external scorer already windows the scores, so
     # no per-window aggregation happens here.
     window_days=1,
-    # softmax_beta = -2.0 (was -0.25) — steeper than every other competition by
-    # design, not scale-matched to them. MEASURED on a real 3h window (2026-08-27,
-    # 11 miners, after the scorer moved to the subnet-parity pipeline): the field
-    # spans 1.186 and -2.0 gives a 10.7x best/worst ratio with a 45% top-3 share,
-    # against 1.19x at -0.15 and 1.43x at -0.3.
+    # softmax_beta is deliberately steeper than the other competitions': this
+    # field is tightly bunched, so a gentler beta leaves rewards nearly flat
+    # across it.
     #
-    # What beta actually responds to is the SPREAD between miners, NOT the absolute
-    # score level: the scorer now subtracts each prompt's winner, and softmax is
-    # invariant to that shared offset, so shifting every score changes nothing. A
-    # widening field therefore concentrates rewards harder at a fixed beta — the
-    # spread doubled between 2026-08-25 and -26 and the ratio moved with it. Revisit
-    # this number if the spread moves materially; re-measure, do not reason from the
-    # score level.
+    # Beta responds to the SPREAD between miners, not the absolute score level:
+    # the scorer subtracts each prompt's winner and softmax is invariant to that
+    # shared offset, so shifting every score changes nothing. A wider field
+    # therefore concentrates rewards harder at a fixed beta. Re-measure before
+    # changing this; do not reason from the score level.
     #
     # MUST stay negative (lower score = higher reward), same convention as the
     # other competitions.
-    softmax_beta=-2.0,
+    softmax_beta=-4.0,
 )
 
 # Plausible size of the VHFT participant field, enforced in
@@ -144,12 +140,11 @@ VHFT_COMPETITION = CompetitionConfig(
 # cycle rather than trusted.
 #
 # The VHFT block is a fixed SMOOTHED_SCORE_COEFFICIENT however many uids share
-# it, so each participant's cut scales as 1/N: at 9 participants the top uid
-# takes ~2.8% of all emissions, at 3 it takes ~8.3%, and at 1 it takes the whole
-# 25%. A round that scores only a handful of miners — a degraded scorer, or a
-# field that has mostly dropped out — would otherwise quietly hand one miner an
-# outsized share, so require a floor. The ceiling is the other end of the same
-# argument: a snapshot naming dozens of scored participants is a malfunctioning
-# scorer rather than a competition that suddenly got popular.
+# it, so each participant's cut scales as 1/N — at one participant that is the
+# entire block. A round that scores only a handful of miners, whether from a
+# degraded scorer or a field that has mostly dropped out, would otherwise hand
+# one miner an outsized share, so require a floor. The ceiling is the other end
+# of the same argument: a snapshot naming far more scored participants than the
+# competition has is a malfunctioning scorer, not sudden popularity.
 VHFT_MIN_PARTICIPANTS = 3
 VHFT_MAX_PARTICIPANTS = 64

--- a/synth/validator/competition_config.py
+++ b/synth/validator/competition_config.py
@@ -117,10 +117,11 @@ VHFT_COMPETITION = CompetitionConfig(
     time_length=10,
     time_increment=10,
     scoring_intervals={"10s": 10},
-    # TODO: calibrate VHFT shaping. window_days is nominal — the external scorer
-    # already windows the scores, so no per-window aggregation happens here.
+    # window_days is nominal — the external scorer already windows the scores, so
+    # no per-window aggregation happens here.
     window_days=1,
-    # TODO: calibrate softmax_beta for the mean_crps scale. MUST stay negative
-    # (lower CRPS = higher reward), same convention as the other competitions.
-    softmax_beta=-0.15,
+    # softmax_beta = -0.25 for the mean_crps scale (steeper than the 24h comps'
+    # -0.15, gentler than Crypto-1h's -0.3). MUST stay negative (lower CRPS =
+    # higher reward), same convention as the other competitions.
+    softmax_beta=-0.25,
 )

--- a/synth/validator/competition_config.py
+++ b/synth/validator/competition_config.py
@@ -103,3 +103,24 @@ ALL_COMPETITIONS = [
     CRYPTO_24H,
     CRYPTO_1H,
 ]
+
+# VHFT (Synth Ultra) — the 10-second BTC-microprice competition. Scored OFF-subnet
+# and blended in via the external-ingestion path (vhft_score_provider +
+# compute_vhft_smoothed_score), NOT through the inline-CRPS path — so it is
+# deliberately kept OUT of ALL_COMPETITIONS. It reuses the same
+# SMOOTHED_SCORE_COEFFICIENT and softmax as the other three, so after set_weights
+# L1-normalizes, the four competitions split emissions equally (the coefficient
+# value cancels; a *shared* coefficient is what makes the split equal).
+VHFT_COMPETITION = CompetitionConfig(
+    asset_list=["BTC"],
+    label="VHFT 10s",
+    time_length=10,
+    time_increment=10,
+    scoring_intervals={"10s": 10},
+    # TODO: calibrate VHFT shaping. window_days is nominal — the external scorer
+    # already windows the scores, so no per-window aggregation happens here.
+    window_days=1,
+    # TODO: calibrate softmax_beta for the mean_crps scale. MUST stay negative
+    # (lower CRPS = higher reward), same convention as the other competitions.
+    softmax_beta=-0.15,
+)

--- a/synth/validator/forward.py
+++ b/synth/validator/forward.py
@@ -43,6 +43,7 @@ from synth.validator.prediction_notifier import PredictionNotifier
 from synth.validator.moving_average import (
     combine_moving_averages,
     compute_smoothed_score,
+    compute_vhft_smoothed_score,
     prepare_df_for_moving_average,
     print_rewards_df,
 )
@@ -92,6 +93,7 @@ def send_weights_to_bittensor_and_update_weights_history(
 def calculate_moving_average_and_update_rewards(
     miner_data_handler: MinerDataHandler,
     scored_time: datetime,
+    vhft_provider=None,
 ) -> list[dict]:
     moving_averages_data: dict[str, list[dict]] = {}
     for comp in competition_config.ALL_COMPETITIONS:
@@ -121,6 +123,24 @@ def calculate_moving_average_and_update_rewards(
 
         miner_data_handler.update_miner_rewards(moving_averages)
         moving_averages_data[comp.label] = moving_averages
+
+    # VHFT: a 4th competition scored OFF-subnet. Pulled from the external scorer and
+    # run through the SAME shape+blend tail as the others. Off (skipped) unless
+    # VHFT_SCORES_URL is set (vhft_provider is None), so this is inert until enabled.
+    if vhft_provider is not None:
+        vhft_scores = vhft_provider.fetch_scores()
+        if vhft_scores:
+            vhft_ma = compute_vhft_smoothed_score(
+                miner_data_handler,
+                vhft_scores,
+                scored_time,
+                competition_config.VHFT_COMPETITION,
+            )
+            if vhft_ma:
+                miner_data_handler.update_miner_rewards(vhft_ma)
+                moving_averages_data[
+                    competition_config.VHFT_COMPETITION.label
+                ] = vhft_ma
 
     return combine_moving_averages(moving_averages_data)
 

--- a/synth/validator/forward.py
+++ b/synth/validator/forward.py
@@ -137,6 +137,14 @@ def calculate_moving_average_and_update_rewards(
                 competition_config.VHFT_COMPETITION,
             )
             if vhft_ma:
+                # Same per-competition log the inline three emit, so VHFT is
+                # auditable from the logs alone. Without it the blend is only
+                # visible in miner_rewards, which is awkward to reach on
+                # mainnet. Inside the guard, unlike the loop above: vhft_ma is
+                # Optional and print_rewards_df would raise on None.
+                print_rewards_df(
+                    vhft_ma, competition_config.VHFT_COMPETITION.label
+                )
                 miner_data_handler.update_miner_rewards(vhft_ma)
                 moving_averages_data[
                     competition_config.VHFT_COMPETITION.label

--- a/synth/validator/miner_data_handler.py
+++ b/synth/validator/miner_data_handler.py
@@ -733,6 +733,22 @@ class MinerDataHandler:
 
         return miner_data
 
+    def get_miner_uid_to_id_map(self) -> dict[int, int] | None:
+        """Managed {miner_uid: miner_id} for the latest identity per uid.
+
+        Used by the VHFT blend to map external per-uid scores to the Postgres
+        miner_id that combine_moving_averages merges on. None on DB failure.
+        """
+        try:
+            with self.engine.connect() as connection:
+                with connection.begin():
+                    return self.get_miner_uids_map(connection)
+        except Exception as e:
+            bt.logging.exception(
+                f"in get_miner_uid_to_id_map (got an exception): {e}"
+            )
+            return None
+
     @retry(
         stop=stop_after_attempt(5),
         wait=wait_random_exponential(multiplier=7),

--- a/synth/validator/miner_data_handler.py
+++ b/synth/validator/miner_data_handler.py
@@ -324,6 +324,16 @@ class MinerDataHandler:
                                     "percentile95": row["percentile95"],
                                     "lowest_score": row["lowest_score"],
                                     "prompt_score_v3": row["prompt_score_v3"],
+                                    # True when the response was clipped to the
+                                    # outlier ceiling. Persisted so the cap rate
+                                    # can be monitored — a rising rate means
+                                    # someone may be provoking it deliberately.
+                                    # Absent on rows written before the cap
+                                    # shipped, so read it as
+                                    # COALESCE(..., false).
+                                    "score_capped": row.get(
+                                        "score_capped", False
+                                    ),
                                     "crps_data": row["crps_data"],
                                 },
                                 "prompt_score_v3": row["prompt_score_v3"],

--- a/synth/validator/moving_average.py
+++ b/synth/validator/moving_average.py
@@ -223,7 +223,11 @@ def compute_vhft_smoothed_score(
         return None
 
     scored = [
-        {"miner_id": uid_to_miner_id[uid], "miner_uid": uid, "rolling_avg": crps}
+        {
+            "miner_id": uid_to_miner_id[uid],
+            "miner_uid": uid,
+            "rolling_avg": crps,
+        }
         for uid, crps in vhft_scores.items()
         if uid in uid_to_miner_id
     ]

--- a/synth/validator/moving_average.py
+++ b/synth/validator/moving_average.py
@@ -198,6 +198,61 @@ def compute_smoothed_score(
     return rewards
 
 
+@print_execution_time
+def compute_vhft_smoothed_score(
+    miner_data_handler: MinerDataHandler,
+    vhft_scores: dict[int, float],
+    scored_time: datetime,
+    comp: CompetitionConfig,
+) -> typing.Optional[list[dict]]:
+    """Shape external VHFT per-uid scores into reward-weight dicts.
+
+    `vhft_scores` is {miner_uid: mean_crps} for VHFT participants only (already
+    windowed by the external scorer), so there is NO per-window aggregation here —
+    we go straight to the same softmax x SMOOTHED_SCORE_COEFFICIENT tail as
+    compute_smoothed_score, keeping shaping uniform across all four competitions.
+
+    Maps uid -> miner_id (the key combine_moving_averages merges on), dropping uids
+    with no Postgres identity (unregistered). Returns None if nothing maps.
+    """
+    if not vhft_scores:
+        return None
+
+    uid_to_miner_id = miner_data_handler.get_miner_uid_to_id_map()
+    if not uid_to_miner_id:
+        return None
+
+    scored = [
+        {"miner_id": uid_to_miner_id[uid], "miner_uid": uid, "rolling_avg": crps}
+        for uid, crps in vhft_scores.items()
+        if uid in uid_to_miner_id
+    ]
+    if not scored:
+        return None
+
+    # Same softmax tail as compute_smoothed_score: negative beta -> lower CRPS wins.
+    reward_weight_list = compute_softmax(
+        np.array([s["rolling_avg"] for s in scored]), comp.softmax_beta
+    )
+
+    rewards = []
+    for item, reward_weight in zip(scored, reward_weight_list):
+        if float(reward_weight) > 0:
+            rewards.append(
+                {
+                    "miner_id": item["miner_id"],
+                    "miner_uid": item["miner_uid"],
+                    "smoothed_score": item["rolling_avg"],
+                    "reward_weight": float(reward_weight)
+                    * SMOOTHED_SCORE_COEFFICIENT,
+                    "updated_at": scored_time.isoformat(),
+                    "prompt_name": comp.label,
+                }
+            )
+
+    return rewards
+
+
 def print_rewards_df(moving_averages_data: list[dict], label: str = ""):
     bt.logging.info(f"Scored responses moving averages {label}")
     df = pd.DataFrame.from_dict(moving_averages_data)

--- a/synth/validator/moving_average.py
+++ b/synth/validator/moving_average.py
@@ -12,6 +12,8 @@ from synth.utils.logging import print_execution_time
 from synth.validator.miner_data_handler import MinerDataHandler
 from synth.validator.competition_config import CompetitionConfig
 from synth.validator.competition_config import SMOOTHED_SCORE_COEFFICIENT
+from synth.validator.competition_config import VHFT_MAX_PARTICIPANTS
+from synth.validator.competition_config import VHFT_MIN_PARTICIPANTS
 from synth.validator.reward import compute_softmax
 
 # Per-asset weighting coefficients for score normalization across assets.
@@ -213,7 +215,11 @@ def compute_vhft_smoothed_score(
     compute_smoothed_score, keeping shaping uniform across all four competitions.
 
     Maps uid -> miner_id (the key combine_moving_averages merges on), dropping uids
-    with no Postgres identity (unregistered). Returns None if nothing maps.
+    with no Postgres identity (unregistered). Returns None if nothing maps, or if
+    the surviving field falls outside VHFT_MIN/MAX_PARTICIPANTS — the block is a
+    fixed share however many miners split it, so too few is a concentration risk
+    and too many is a malfunctioning scorer. Either way the caller skips VHFT for
+    the cycle and the other three competitions still set weights.
     """
     if not vhft_scores:
         return None
@@ -232,6 +238,19 @@ def compute_vhft_smoothed_score(
         if uid in uid_to_miner_id
     ]
     if not scored:
+        return None
+
+    # Concentration guard. Checked AFTER the identity mapping above, on the
+    # miners that will actually be paid: 9 scored uids of which only 1 is
+    # registered concentrates exactly as hard as 1 scored uid, and a raw
+    # len(vhft_scores) check would miss that.
+    if not VHFT_MIN_PARTICIPANTS <= len(scored) <= VHFT_MAX_PARTICIPANTS:
+        bt.logging.warning(
+            f"VHFT: {len(scored)} scored participant(s) outside the plausible "
+            f"range [{VHFT_MIN_PARTICIPANTS}, {VHFT_MAX_PARTICIPANTS}] — "
+            f"skipping the VHFT blend this cycle rather than concentrating "
+            f"its share on too few miners"
+        )
         return None
 
     # Same softmax tail as compute_smoothed_score: negative beta -> lower CRPS wins.

--- a/synth/validator/reward.py
+++ b/synth/validator/reward.py
@@ -208,14 +208,22 @@ def _build_detailed_info(
     miner_prediction_process_time: list,
     percentile95: float,
     lowest_score: float,
+    was_capped: np.ndarray,
 ) -> list[dict]:
-    """Build detailed information dict from processing results."""
+    """Build detailed information dict from processing results.
+
+    score_capped marks a response clipped to the outlier ceiling. It is what
+    makes the cap monitorable after the fact — a rising rate is the signal that
+    someone is provoking it to inflate the field rather than merely predicting
+    badly.
+    """
     return [
         {
             "miner_uid": pred.miner_uid,
             "prompt_score_v3": float(prompt_score),
             "percentile95": float(percentile95),
             "lowest_score": float(lowest_score),
+            "score_capped": bool(capped),
             "miner_prediction_id": prediction_id,
             "format_validation": format,
             "process_time": process_time,
@@ -230,6 +238,7 @@ def _build_detailed_info(
             format,
             prediction_id,
             process_time,
+            capped,
         ) in zip(
             predictions,
             scores,
@@ -238,6 +247,7 @@ def _build_detailed_info(
             miner_prediction_format_list,
             miner_prediction_id_list,
             miner_prediction_process_time,
+            was_capped,
         )
     ]
 
@@ -346,8 +356,8 @@ def get_rewards_multiprocess(
         miner_prediction_process_time.append(process_time)
 
     score_values = np.array(scores)
-    prompt_scores, percentile95, lowest_score = compute_prompt_scores(
-        score_values
+    prompt_scores, percentile95, lowest_score, was_capped = (
+        compute_prompt_scores(score_values)
     )
 
     if prompt_scores is None:
@@ -366,21 +376,95 @@ def get_rewards_multiprocess(
         miner_prediction_process_time,
         percentile95,
         lowest_score,
+        was_capped,
     )
 
     return prompt_scores, detailed_info, real_prices
 
 
+# Ceiling on a single miner's CRPS, as a multiple of the field's MEDIAN.
+#
+# Response validation only rejects prices above the float32 ceiling (~3.4e38),
+# so a forecast of 1e30 is accepted as CORRECT and produces a CRPS of the same
+# order. Uncapped, one such response does two kinds of damage:
+#
+#   1. It lands in the p95 that fills MISSED responses, so a miner that merely
+#      timed out inherits an astronomical score it had no part in producing.
+#   2. It survives into the moving average, where exp(beta * score) underflows
+#      to exactly 0.0 — and compute_smoothed_score drops zero-weight miners
+#      entirely, so the miner vanishes from the results rather than ranking last.
+#
+# The multiple was chosen against real scoring history: responses beyond 10x
+# their prompt's median are vanishingly rare and, where they occur, are already
+# unusable. Real predictions do not spread that far, so this never touches
+# legitimate scoring and does not change a miner's optimum strategy.
+#
+# A much larger multiple was tried first and rejected. It leaves the capped
+# value orders of magnitude above a normal score, which distorts dashboards and,
+# for a miner capped on several prompts, pushes the windowed mean back toward
+# the underflow-to-zero behaviour this exists to prevent. 10x keeps a capped row
+# on the same scale as the rest of the field.
+#
+# This is NOT the p90 cap removed in #302: that compressed ordinary scores,
+# whereas at 10x nothing ordinary is touched at all.
+#
+# The median is the right basis because it is unmoved by a large minority of
+# garbage — the p95 is precisely what garbage captures first.
+OUTLIER_SCORE_MEDIAN_MULTIPLE = 10.0
+
+
 @print_execution_time
 def compute_prompt_scores(score_values: np.ndarray):
+    """Returns (prompt_scores, percentile95, lowest_score, was_capped).
+
+    was_capped is a bool array aligned with score_values, True where a response
+    was clipped to the outlier ceiling. It is persisted per row so the cap is
+    monitorable — if the rate ever climbs, someone may be provoking it
+    deliberately to inflate the field.
+    """
     if np.all(score_values == -1):
-        return None, 0, 0
+        return None, 0, 0, None
+    score_values = np.asarray(score_values, dtype=float)
     score_values_valid = score_values[score_values != -1]
-    percentile95 = np.percentile(score_values_valid, 95)
-    # Valid scores are not capped; only missed responses (-1) are filled.
+
+    # Clip absurd outliers BEFORE deriving anything from them. The cap is taken
+    # on the RAW crps, before the best score is subtracted: raw crps has a
+    # stable positive scale set by the asset's price, whereas post-subtraction
+    # scores start at 0 and a tightly-bunched field would give a median near
+    # zero — collapsing a median-multiple cap onto legitimate scores.
+    median = float(np.median(score_values_valid))
+    # Aligned with score_values, so it can be persisted per row. Misses (-1) are
+    # below any positive cap and so are never flagged.
+    was_capped = np.zeros(score_values.shape, dtype=bool)
+    if median > 0:
+        cap = median * OUTLIER_SCORE_MEDIAN_MULTIPLE
+        was_capped = score_values > cap
+        if was_capped.any():
+            bt.logging.warning(
+                f"{int(was_capped.sum())} of {score_values_valid.size} valid "
+                f"response(s) exceeded {OUTLIER_SCORE_MEDIAN_MULTIPLE:g}x the "
+                f"median CRPS ({median:.4g}); clipping to {cap:.4g} and "
+                f"excluding them from the p95 used to fill missed responses."
+            )
+        # cap > 0, so np.minimum leaves the -1 miss sentinels untouched.
+        score_values = np.minimum(score_values, cap)
+
+    # The p95 that fills MISSED responses is taken over the scores that were NOT
+    # capped. Clipping alone is not enough: once more than 5% of the field is
+    # garbage the p95 lands on the cap itself, so a miner that merely timed out
+    # still inherits a near-fatal score it had no part in producing. Excluding
+    # capped scores keeps the two cases properly separated — submit garbage and
+    # you are capped and ranked last; miss the prompt and you are scored like
+    # the 95th percentile of the miners who actually answered.
+    uncapped = score_values[(score_values != -1) & ~was_capped]
+    percentile95 = np.percentile(
+        uncapped if uncapped.size else score_values[score_values != -1], 95
+    )
+    # Valid scores are capped (above) but not otherwise compressed; only missed
+    # responses (-1) are filled.
     filled_scores = np.where(score_values == -1, percentile95, score_values)
     lowest_score = np.min(filled_scores)
-    return filled_scores - lowest_score, percentile95, lowest_score
+    return filled_scores - lowest_score, percentile95, lowest_score, was_capped
 
 
 def compute_softmax(score_values: np.ndarray, beta: float) -> np.ndarray:

--- a/synth/validator/vhft_score_provider.py
+++ b/synth/validator/vhft_score_provider.py
@@ -1,0 +1,73 @@
+"""Optional ingestion of external VHFT (Synth Ultra) competition scores.
+
+VHFT is the 10-second BTC-microprice competition, scored OFF-subnet by a separate
+scorer that exposes per-uid raw scores over HTTP. When VHFT_SCORES_URL is set, the
+validator pulls those scores each scoring cycle and blends them in as a 4th
+competition (see forward.calculate_moving_average_and_update_rewards). Disabled —
+from_env() returns None — when the env var is unset, so this is inert until
+explicitly configured (safe to merge).
+
+Best-effort: any fetch/parse failure returns None and VHFT is simply skipped for
+that cycle; the other three competitions still set weights.
+"""
+
+import os
+import typing
+
+import bittensor as bt
+import requests
+
+_DEFAULT_TIMEOUT_S = 10
+
+
+class VhftScoreProvider:
+    def __init__(self, url: str):
+        self._url = url
+        bt.logging.info(f"VHFT score provider enabled (url: {self._url})")
+
+    @staticmethod
+    def from_env() -> typing.Optional["VhftScoreProvider"]:
+        """Build from VHFT_SCORES_URL; returns None (disabled) when unset."""
+        url = os.getenv("VHFT_SCORES_URL")
+        if not url:
+            return None
+        return VhftScoreProvider(url=url)
+
+    def fetch_scores(self) -> typing.Optional[dict[int, float]]:
+        """Return {miner_uid: mean_crps} for VHFT participants only.
+
+        The /v1/scores endpoint returns all 256 uids, with mean_crps=0.0 (and
+        weight=0.0) for non-participants. Those are EXCLUDED here: 0.0 would read
+        as a *perfect* score to the lower-is-better softmax downstream, wrongly
+        rewarding miners that never competed in VHFT. We keep only uids the scorer
+        gave positive weight (i.e. actually-scored participants) and return their
+        raw mean_crps (the blend applies its own softmax, so pass the raw score,
+        not the pre-normalized weight).
+
+        Returns None on any HTTP/parse failure or when no participants are scored,
+        so the caller skips VHFT this cycle rather than crashing the scoring loop.
+
+        TODO: the endpoint returns uid but not hotkey, so a uid that deregistered
+        and re-registered between the scorer's window and the validator's metagraph
+        could be misattributed. Add hotkey to /v1/scores and validate it against the
+        metagraph for robustness.
+        """
+        try:
+            resp = requests.get(self._url, timeout=_DEFAULT_TIMEOUT_S)
+            resp.raise_for_status()
+            rows = resp.json().get("scores", [])
+        except Exception as e:
+            bt.logging.warning(
+                f"VHFT fetch_scores failed (skipping VHFT this cycle): {e}"
+            )
+            return None
+
+        scores = {
+            int(r["uid"]): float(r["mean_crps"])
+            for r in rows
+            if float(r.get("weight", 0.0)) > 0.0
+        }
+        if not scores:
+            bt.logging.info("VHFT: no scored participants this cycle")
+            return None
+        return scores

--- a/synth/validator/vhft_score_provider.py
+++ b/synth/validator/vhft_score_provider.py
@@ -28,9 +28,15 @@ def _parse_score_row(row: typing.Any) -> typing.Optional[tuple[int, float]]:
     not worth logging.
 
     Raises TypeError/ValueError/KeyError for a row that claims participation but
-    cannot be used: a null or non-positive mean_crps, or a malformed uid/weight.
+    cannot be used: a null or NEGATIVE mean_crps, or a malformed uid/weight.
     The caller counts those and warns, because unlike a weight-0.0 row they mean
     the scorer sent something unexpected.
+
+    0.0 is a LEGITIMATE score, not a rejection: the scorer publishes field-relative
+    scores (each prompt's best miner scores 0, matching the subnet's own
+    compute_prompt_scores), so a miner that wins every prompt in the window averages
+    exactly 0.0. Non-participants also read 0.0, which is why `weight > 0` — not the
+    score — is the participation test, and why that check must stay first.
     """
     if float(row.get("weight") or 0.0) <= 0.0:
         return None
@@ -38,8 +44,8 @@ def _parse_score_row(row: typing.Any) -> typing.Optional[tuple[int, float]]:
     if mean_crps is None:
         raise ValueError("null mean_crps on a positive-weight row")
     crps = float(mean_crps)
-    if crps <= 0.0:
-        raise ValueError(f"non-positive mean_crps {crps!r}")
+    if crps < 0.0:
+        raise ValueError(f"negative mean_crps {crps!r}")
     return int(row["uid"]), crps
 
 
@@ -73,17 +79,25 @@ class VhftScoreProvider:
         is a real perfect-CRPS value). A null on a positive-weight row is dropped
         rather than coerced, and so is any row with a malformed uid/weight.
 
-        A non-positive mean_crps on a positive-weight row is ALSO dropped, and
-        that filter is load-bearing. After a restart the scorer can serve a
-        placeholder snapshot written before it has scored anything, giving every
-        uid a nonzero weight and a 0.0 CRPS. Filtering on weight alone lets that
-        through, and 0.0 reads as a *perfect* score to the lower-is-better
-        softmax downstream — i.e. the VHFT block's whole share of emissions
-        spread across every registered miner, none of whom competed. Filtering
-        on crps is what actually excludes non-participants; weight only
-        distinguishes them once the scorer has real results. A genuine 0.0 would
-        need a point-mass prediction landing exactly on the realized price for
-        every observation in the window, so dropping it costs a cycle at most.
+        A NEGATIVE mean_crps is dropped (impossible by construction). 0.0 is NOT
+        dropped, and that is a deliberate reversal: the scorer now publishes
+        field-relative scores, where each prompt's best miner scores 0 (matching
+        the subnet's own compute_prompt_scores), so the window's best miner
+        legitimately averages 0.0. The previous rule — drop any non-positive score,
+        justified because a genuine 0.0 needed a point-mass prediction landing
+        exactly on the realized price — would now systematically exclude the
+        WINNER from every cycle.
+
+        The protection that rule provided is preserved by the degenerate-snapshot
+        guard below. The incident it defends against is a post-restart placeholder
+        snapshot: every uid at a nonzero weight and an identical score, which would
+        spread the VHFT block's whole share across every registered miner, none of
+        whom competed. That snapshot's signature is that ALL scores are identical,
+        which is now what we test for — and unlike the old rule it catches a
+        degenerate snapshot at any value, not only at 0.0. Two further layers back
+        it up: the scorer refuses to publish while its book is empty, and
+        compute_vhft_smoothed_score skips any field outside
+        [VHFT_MIN_PARTICIPANTS, VHFT_MAX_PARTICIPANTS].
 
         Returns None on any HTTP/parse failure or when no participants are scored,
         so the caller skips VHFT this cycle rather than crashing the scoring loop.
@@ -117,9 +131,21 @@ class VhftScoreProvider:
         if dropped:
             bt.logging.warning(
                 f"VHFT: dropped {dropped} unusable score row(s) "
-                f"(null/non-positive mean_crps or malformed uid/weight)"
+                f"(null/negative mean_crps or malformed uid/weight)"
             )
         if not scores:
             bt.logging.info("VHFT: no scored participants this cycle")
+            return None
+        # Degenerate-snapshot guard. Real field-relative scores over a 24h window are
+        # never all equal (that would need every miner to tie on every prompt), so an
+        # identical-score field means a placeholder/degraded snapshot, not a result.
+        # Replaces the old "drop non-positive crps" rule, which cannot survive scores
+        # that legitimately start at 0. See the docstring.
+        if len(scores) > 1 and len(set(scores.values())) == 1:
+            bt.logging.warning(
+                f"VHFT: all {len(scores)} scored uids share an identical score "
+                f"({next(iter(scores.values()))!r}) — treating as a placeholder "
+                f"snapshot and skipping VHFT this cycle"
+            )
             return None
         return scores

--- a/synth/validator/vhft_score_provider.py
+++ b/synth/validator/vhft_score_provider.py
@@ -20,6 +20,29 @@ import requests
 _DEFAULT_TIMEOUT_S = 10
 
 
+def _parse_score_row(row: typing.Any) -> typing.Optional[tuple[int, float]]:
+    """Return (uid, mean_crps) for one scored participant.
+
+    None means "not a participant this cycle" — the steady-state snapshot is 9
+    scored uids and 247 at weight 0.0, so that is the common, expected case and
+    not worth logging.
+
+    Raises TypeError/ValueError/KeyError for a row that claims participation but
+    cannot be used: a null or non-positive mean_crps, or a malformed uid/weight.
+    The caller counts those and warns, because unlike a weight-0.0 row they mean
+    the scorer sent something unexpected.
+    """
+    if float(row.get("weight") or 0.0) <= 0.0:
+        return None
+    mean_crps = row.get("mean_crps")
+    if mean_crps is None:
+        raise ValueError("null mean_crps on a positive-weight row")
+    crps = float(mean_crps)
+    if crps <= 0.0:
+        raise ValueError(f"non-positive mean_crps {crps!r}")
+    return int(row["uid"]), crps
+
+
 class VhftScoreProvider:
     def __init__(self, url: str):
         self._url = url
@@ -50,6 +73,18 @@ class VhftScoreProvider:
         is a real perfect-CRPS value). A null on a positive-weight row is dropped
         rather than coerced, and so is any row with a malformed uid/weight.
 
+        A non-positive mean_crps on a positive-weight row is ALSO dropped, and
+        that filter is load-bearing. After a restart the scorer can serve a
+        placeholder snapshot written before it has scored anything, giving every
+        uid a nonzero weight and a 0.0 CRPS. Filtering on weight alone lets that
+        through, and 0.0 reads as a *perfect* score to the lower-is-better
+        softmax downstream — i.e. the VHFT block's whole share of emissions
+        spread across every registered miner, none of whom competed. Filtering
+        on crps is what actually excludes non-participants; weight only
+        distinguishes them once the scorer has real results. A genuine 0.0 would
+        need a point-mass prediction landing exactly on the realized price for
+        every observation in the window, so dropping it costs a cycle at most.
+
         Returns None on any HTTP/parse failure or when no participants are scored,
         so the caller skips VHFT this cycle rather than crashing the scoring loop.
 
@@ -72,20 +107,17 @@ class VhftScoreProvider:
         dropped = 0
         for r in rows:
             try:
-                if float(r.get("weight") or 0.0) <= 0.0:
-                    continue
-                mean_crps = r.get("mean_crps")
-                if mean_crps is None:
-                    dropped += 1
-                    continue
-                scores[int(r["uid"])] = float(mean_crps)
-            except (TypeError, ValueError, KeyError):
+                parsed = _parse_score_row(r)
+            except (TypeError, ValueError, KeyError, AttributeError):
                 dropped += 1
+                continue
+            if parsed is not None:
+                scores[parsed[0]] = parsed[1]
 
         if dropped:
             bt.logging.warning(
                 f"VHFT: dropped {dropped} unusable score row(s) "
-                f"(null mean_crps or malformed uid/weight)"
+                f"(null/non-positive mean_crps or malformed uid/weight)"
             )
         if not scores:
             bt.logging.info("VHFT: no scored participants this cycle")

--- a/synth/validator/vhft_score_provider.py
+++ b/synth/validator/vhft_score_provider.py
@@ -44,6 +44,12 @@ class VhftScoreProvider:
         raw mean_crps (the blend applies its own softmax, so pass the raw score,
         not the pre-normalized weight).
 
+        Rows are parsed defensively: mean_crps is null whenever the scorer could
+        not attach one (older snapshots, or a uid/mean_crps length mismatch — see
+        bigtable_scores_provider, where null is the deliberate sentinel because 0.0
+        is a real perfect-CRPS value). A null on a positive-weight row is dropped
+        rather than coerced, and so is any row with a malformed uid/weight.
+
         Returns None on any HTTP/parse failure or when no participants are scored,
         so the caller skips VHFT this cycle rather than crashing the scoring loop.
 
@@ -62,11 +68,25 @@ class VhftScoreProvider:
             )
             return None
 
-        scores = {
-            int(r["uid"]): float(r["mean_crps"])
-            for r in rows
-            if float(r.get("weight", 0.0)) > 0.0
-        }
+        scores: dict[int, float] = {}
+        dropped = 0
+        for r in rows:
+            try:
+                if float(r.get("weight") or 0.0) <= 0.0:
+                    continue
+                mean_crps = r.get("mean_crps")
+                if mean_crps is None:
+                    dropped += 1
+                    continue
+                scores[int(r["uid"])] = float(mean_crps)
+            except (TypeError, ValueError, KeyError):
+                dropped += 1
+
+        if dropped:
+            bt.logging.warning(
+                f"VHFT: dropped {dropped} unusable score row(s) "
+                f"(null mean_crps or malformed uid/weight)"
+            )
         if not scores:
             bt.logging.info("VHFT: no scored participants this cycle")
             return None

--- a/tests/test_miner_data_handler.py
+++ b/tests/test_miner_data_handler.py
@@ -1659,3 +1659,74 @@ def test_cleanup_old_history_deletes_bigtable_rows(db_engine: Engine):
     assert old_row.deleted_at is not None
     assert fresh_row.deleted_at is None
     assert fake.delete_calls == [(LOW_TEST_CONFIG.time_length, ["bt-key-old"])]
+
+
+def test_set_miner_scores_persists_the_score_capped_flag(db_engine: Engine):
+    """score_capped must survive the write into score_details_v3.
+
+    Regression: the flag is computed in reward._build_detailed_info, but
+    set_miner_scores does not store the detail dict wholesale — it copies a
+    fixed list of keys into the JSONB. A flag added upstream without being
+    added here is silently dropped, and the cap becomes unmonitorable.
+
+    Also pins the back-compat default: rows scored before the cap shipped carry
+    no flag, so a missing key must write False rather than raising.
+    """
+    handler = MinerDataHandler(db_engine)
+    start_time = "2024-11-20T00:00:00+00:00"
+    scored_time = datetime.fromisoformat("2024-11-22T00:00:00+00:00")
+
+    handler, _, _ = prepare_random_predictions(db_engine, start_time)
+    validator_requests = handler.get_validator_requests_to_score(
+        scored_time, 7, 86400, ["HYPE"]
+    )
+    assert len(validator_requests) >= 1
+
+    with db_engine.connect() as connection:
+        predictions = connection.execute(
+            select(MinerPrediction.id).where(
+                MinerPrediction.validator_requests_id
+                == validator_requests[0].id
+            )
+        ).fetchall()
+    assert len(predictions) >= 2
+
+    reward_details = []
+    for i, pred in enumerate(predictions):
+        row = {
+            "miner_uid": i,
+            "miner_prediction_id": pred.id,
+            "total_crps": 1.0,
+            "percentile95": 1.0,
+            "lowest_score": 0.01,
+            "prompt_score_v3": 1.0,
+            "crps_data": [{"crps": 1.0}],
+        }
+        # first miner capped, second explicitly not, third omits the key
+        # entirely (the pre-cap shape)
+        if i == 0:
+            row["score_capped"] = True
+        elif i == 1:
+            row["score_capped"] = False
+        reward_details.append(row)
+
+    handler.set_miner_scores(
+        [], int(validator_requests[0].id), reward_details, scored_time
+    )
+
+    with db_engine.connect() as connection:
+        results = connection.execute(
+            select(MinerScore.score_details_v3)
+            .where(
+                MinerScore.miner_predictions_id.in_(
+                    [p.id for p in predictions]
+                )
+            )
+            .order_by(MinerScore.miner_predictions_id)
+        ).fetchall()
+
+    assert results[0][0]["score_capped"] is True
+    assert results[1][0]["score_capped"] is False
+    if len(results) > 2:
+        # omitted upstream -> stored as False, never missing and never an error
+        assert results[2][0]["score_capped"] is False

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -9,6 +9,7 @@ from sqlalchemy import delete
 from synth.db.models import MinerPrediction, ValidatorRequest, MinerScore
 from synth.validator.price_data_provider import PriceDataProvider
 from synth.validator.reward import (
+    OUTLIER_SCORE_MEDIAN_MULTIPLE,
     _crps_worker,
     compute_prompt_scores,
     compute_softmax,
@@ -51,7 +52,7 @@ def test_compute_prompt_scores():
     # percentile of the valid scores (1950), then shifted by the minimum.
     expected_prompt_scores = np.array([0, 500, 1000, 950])
 
-    actual_score, percentile95, lowest_score = compute_prompt_scores(
+    actual_score, percentile95, lowest_score, _ = compute_prompt_scores(
         crps_scores
     )
 
@@ -66,13 +67,105 @@ def test_compute_prompt_scores_only_one_miner():
         [0, 0, 0, 0]
     )  # TODO: not ideal but it's the current behavior
 
-    actual_score, percentile95, lowest_score = compute_prompt_scores(
+    actual_score, percentile95, lowest_score, _ = compute_prompt_scores(
         crps_scores
     )
 
     assert percentile95 == 1000
     assert lowest_score == 1000
     assert np.array_equal(actual_score, expected_prompt_scores)
+
+
+def test_absurd_response_does_not_poison_the_fill_for_missed_responses():
+    """A minority of absurd responses must not poison the fill for a miss.
+
+    Prices are only rejected above the float32 ceiling, so an accepted response
+    can carry an enormous CRPS. Uncapped, a small minority of those pulls the
+    p95 up — and p95 is what fills a MISSED response, so a miner that merely
+    timed out inherits the value, exp(beta * score) underflows to exactly 0, and
+    compute_smoothed_score drops it from the rewards list for the whole window.
+
+    The miss must come back with a bad-but-survivable score, not an
+    astronomical one.
+    """
+    # A legitimate field with real spread, a minority of absurd responses, then
+    # one miner that missed.
+    legit = [20.0, 22.0, 25.0, 28.0, 30.0, 33.0, 36.0, 40.0, 45.0, 50.0, 60.0]
+    field = legit + [1e12, 1e12] + [-1.0]
+    scores, percentile95, lowest, capped = compute_prompt_scores(
+        np.array(field)
+    )
+
+    # The fill is the 95th percentile of the miners who actually ANSWERED, so
+    # it sits inside the legitimate range — not on the cap, and nowhere near
+    # the garbage that caused the incident.
+    assert min(legit) <= percentile95 <= max(legit)
+
+    # The miner that missed is scored like a bad-but-real miner...
+    missed = scores[-1]
+    assert missed == pytest.approx(percentile95 - lowest)
+    assert missed <= max(legit) - min(legit)
+    # ...while the two that submitted garbage are capped and ranked last.
+    assert scores[11] == scores[12] > missed
+
+    # What actually decides whether a miner is paid: the prompt is averaged
+    # into a ~10-day window. Uncapped, one poisoned row dominated that mean and
+    # exp(beta * mean) underflowed to a hard zero, which compute_smoothed_score
+    # drops from the rewards list entirely.
+    window = 1900
+
+    def mean_with(row):
+        return (row + (window - 1) * 30.0) / window
+
+    assert compute_softmax(np.array([mean_with(missed)]), -0.15)[0] > 0
+    # ...and the uncapped value is exactly what that guards against.
+    assert np.exp(-0.15 * mean_with(1e12)) == 0.0
+
+
+def test_outlier_is_clipped_but_ordinary_bad_scores_are_untouched():
+    """The cap separates a real response from an impossible one.
+
+    It is not the p90 cap removed in #302, which compressed ordinary scores.
+    Responses beyond 10x their prompt's median are vanishingly rare in real
+    scoring history, so nothing ordinary is touched here.
+    """
+    median = 30.0
+    cap = median * OUTLIER_SCORE_MEDIAN_MULTIPLE
+    # 5x the median is a genuinely bad but entirely real response.
+    field = np.array([median] * 10 + [median * 5, 1e12, 1e30])
+    scores, _, lowest, capped = compute_prompt_scores(field)
+
+    # The legitimately-bad miner keeps its real score, undistorted and unflagged.
+    assert scores[10] == pytest.approx(median * 5 - lowest)
+    assert not capped[10]
+    # Both garbage responses land on the cap, tied at "worst", and are flagged.
+    assert scores[11] == pytest.approx(cap - lowest)
+    assert scores[11] == scores[12]
+    assert capped[11] and capped[12]
+    # The flag is what makes the cap monitorable; only the garbage carries it.
+    assert capped.sum() == 2
+
+
+def test_capped_flag_is_aligned_with_the_input_and_excludes_misses():
+    """The flag is persisted per row, so it must line up with score_values.
+
+    A miss (-1) is below any positive cap and must never be flagged as capped.
+    """
+    field = np.array([10.0, 12.0, 1e9, -1.0, 11.0])
+    _, _, _, capped = compute_prompt_scores(field)
+
+    assert capped.shape == field.shape
+    assert list(capped) == [False, False, True, False, False]
+
+
+def test_all_absurd_field_does_not_divide_by_a_zero_median():
+    # Degenerate guard: a field with a zero median must not produce a zero cap
+    # that clips every score to nothing.
+    scores, percentile95, _, _ = compute_prompt_scores(
+        np.array([0.0, 0.0, 0.0, 5.0])
+    )
+    assert np.all(np.isfinite(scores))
+    assert percentile95 == pytest.approx(4.25)
 
 
 def test_crps_worker_drops_non_finite_detailed_data():

--- a/tests/test_vhft_blend.py
+++ b/tests/test_vhft_blend.py
@@ -20,6 +20,19 @@ from synth.validator.moving_average import compute_vhft_smoothed_score
 SCORED_TIME = datetime(2026, 8, 24, 12, 0, tzinfo=timezone.utc)
 
 
+def _field(n):
+    """A plausible scored field of n uids, with a DISTINCT score each.
+
+    Deliberately not a flat field. Scores are field-relative (each prompt's winner
+    scores 0), and a real one is never all-equal over a full window — an identical
+    field is the signature of a placeholder/degraded snapshot, which
+    VhftScoreProvider.fetch_scores rejects outright. These tests call
+    compute_vhft_smoothed_score directly and so bypass that guard, but they should not
+    ship an example of the exact shape it exists to reject.
+    """
+    return {uid: 0.4 + uid / 100 for uid in range(n)}
+
+
 def _handler(registered_uids):
     """MinerDataHandler stub mapping each uid to a distinct miner_id."""
     handler = MagicMock()
@@ -41,7 +54,7 @@ def _blend(vhft_scores, registered_uids=None):
 
 
 def test_steady_state_field_blends_and_splits_the_block_evenly():
-    scores = {uid: 0.4 for uid in range(9)}
+    scores = _field(9)
     rewards = _blend(scores)
 
     assert rewards is not None
@@ -65,12 +78,12 @@ def test_lower_crps_earns_more_than_higher_crps():
 def test_too_few_participants_skips_the_cycle(n):
     # The block is a fixed share however many split it, so at n=1 a single
     # miner would take the whole 25% of emissions.
-    assert _blend({uid: 0.4 for uid in range(n)}) is None
+    assert _blend(_field(n)) is None
 
 
 def test_too_many_participants_skips_the_cycle():
     n = VHFT_MAX_PARTICIPANTS + 1
-    assert _blend({uid: 0.4 for uid in range(n)}) is None
+    assert _blend(_field(n)) is None
 
 
 def test_guard_counts_paid_miners_not_returned_uids():
@@ -80,12 +93,12 @@ def test_guard_counts_paid_miners_not_returned_uids():
     exactly as hard as a field of 2, so counting the raw scorer response would
     miss it.
     """
-    scores = {uid: 0.4 for uid in range(9)}
+    scores = _field(9)
     assert _blend(scores, registered_uids=[0, 1]) is None
 
 
 def test_unregistered_uids_are_dropped_but_a_valid_field_still_blends():
-    scores = {uid: 0.4 for uid in range(9)}
+    scores = _field(9)
     registered = list(range(5))
     rewards = _blend(scores, registered_uids=registered)
 

--- a/tests/test_vhft_blend.py
+++ b/tests/test_vhft_blend.py
@@ -1,0 +1,111 @@
+"""Unit tests for the VHFT blend in moving_average.compute_vhft_smoothed_score.
+
+Covers the concentration guard and the equal-split invariant. The DB is a
+MagicMock — only get_miner_uid_to_id_map() is consulted.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from synth.validator.competition_config import (
+    SMOOTHED_SCORE_COEFFICIENT,
+    VHFT_COMPETITION,
+    VHFT_MAX_PARTICIPANTS,
+    VHFT_MIN_PARTICIPANTS,
+)
+from synth.validator.moving_average import compute_vhft_smoothed_score
+
+SCORED_TIME = datetime(2026, 8, 24, 12, 0, tzinfo=timezone.utc)
+
+
+def _handler(registered_uids):
+    """MinerDataHandler stub mapping each uid to a distinct miner_id."""
+    handler = MagicMock()
+    handler.get_miner_uid_to_id_map.return_value = {
+        uid: 1000 + uid for uid in registered_uids
+    }
+    return handler
+
+
+def _blend(vhft_scores, registered_uids=None):
+    if registered_uids is None:
+        registered_uids = list(vhft_scores)
+    return compute_vhft_smoothed_score(
+        _handler(registered_uids),
+        vhft_scores,
+        SCORED_TIME,
+        VHFT_COMPETITION,
+    )
+
+
+def test_steady_state_field_blends_and_splits_the_block_evenly():
+    scores = {uid: 0.4 for uid in range(9)}
+    rewards = _blend(scores)
+
+    assert rewards is not None
+    assert len(rewards) == 9
+    # The invariant the equal 4-way emissions split rests on: every competition
+    # contributes exactly SMOOTHED_SCORE_COEFFICIENT, so after set_weights
+    # L1-normalizes, four competitions land at 25% each.
+    total = sum(r["reward_weight"] for r in rewards)
+    assert total == pytest.approx(SMOOTHED_SCORE_COEFFICIENT)
+    assert all(r["prompt_name"] == VHFT_COMPETITION.label for r in rewards)
+
+
+def test_lower_crps_earns_more_than_higher_crps():
+    # softmax_beta must stay negative: VHFT is lower-is-better like the rest.
+    rewards = _blend({1: 0.1, 2: 0.4, 3: 5.0})
+    by_uid = {r["miner_uid"]: r["reward_weight"] for r in rewards}
+    assert by_uid[1] > by_uid[2] > by_uid[3]
+
+
+@pytest.mark.parametrize("n", [1, VHFT_MIN_PARTICIPANTS - 1])
+def test_too_few_participants_skips_the_cycle(n):
+    # The block is a fixed share however many split it, so at n=1 a single
+    # miner would take the whole 25% of emissions.
+    assert _blend({uid: 0.4 for uid in range(n)}) is None
+
+
+def test_too_many_participants_skips_the_cycle():
+    n = VHFT_MAX_PARTICIPANTS + 1
+    assert _blend({uid: 0.4 for uid in range(n)}) is None
+
+
+def test_guard_counts_paid_miners_not_returned_uids():
+    """Regression: the guard runs AFTER the uid -> miner_id mapping.
+
+    A field of 9 scored uids of which only 2 are registered concentrates
+    exactly as hard as a field of 2, so counting the raw scorer response would
+    miss it.
+    """
+    scores = {uid: 0.4 for uid in range(9)}
+    assert _blend(scores, registered_uids=[0, 1]) is None
+
+
+def test_unregistered_uids_are_dropped_but_a_valid_field_still_blends():
+    scores = {uid: 0.4 for uid in range(9)}
+    registered = list(range(5))
+    rewards = _blend(scores, registered_uids=registered)
+
+    assert rewards is not None
+    assert {r["miner_uid"] for r in rewards} == set(registered)
+    # Dropping uids does not leak emissions: the block still sums to its share.
+    total = sum(r["reward_weight"] for r in rewards)
+    assert total == pytest.approx(SMOOTHED_SCORE_COEFFICIENT)
+
+
+def test_returns_none_when_there_is_nothing_to_blend():
+    assert _blend({}) is None
+
+
+def test_returns_none_when_the_identity_map_is_unavailable():
+    handler = MagicMock()
+    handler.get_miner_uid_to_id_map.return_value = None
+    assert (
+        compute_vhft_smoothed_score(
+            handler, {1: 0.4}, SCORED_TIME, VHFT_COMPETITION
+        )
+        is None
+    )

--- a/tests/test_vhft_score_provider.py
+++ b/tests/test_vhft_score_provider.py
@@ -1,8 +1,9 @@
 """Unit tests for vhft_score_provider.py — no DB or network required.
 
-Covers the /v1/scores parsing contract: only positive-weight rows are kept, a
-null mean_crps is dropped rather than coerced, and every failure mode returns
-None so the scoring cycle skips VHFT instead of raising.
+Covers the /v1/scores parsing contract: only rows with positive weight AND
+positive mean_crps are kept, a null mean_crps is dropped rather than coerced,
+and every failure mode returns None so the scoring cycle skips VHFT instead of
+raising.
 """
 
 from unittest.mock import MagicMock, patch
@@ -94,6 +95,60 @@ def test_malformed_row_is_dropped():
     assert scores == {14: 25.5}
 
 
+def test_bootstrap_snapshot_is_rejected():
+    """Regression: a post-restart placeholder snapshot must not read as a full
+    field of perfect scores.
+
+    After a restart /v1/scores can serve every uid at a nonzero weight with
+    mean_crps=0.0, written before the first real scoring round. Filtering on
+    weight alone let all of them through, and 0.0 is the *best* possible value
+    to the lower-is-better softmax, so the VHFT block's whole share of emissions
+    would be spread across every registered miner — none of whom competed.
+    """
+    bootstrap = {
+        "scores": [
+            {"uid": uid, "weight": 1 / 256, "mean_crps": 0.0}
+            for uid in range(256)
+        ]
+    }
+    assert _fetch(bootstrap) is None
+
+
+def test_zero_crps_row_is_dropped_but_healthy_peers_survive():
+    # A partial bootstrap/degraded snapshot must not poison the whole cycle:
+    # drop only the 0.0 rows and keep scoring the real participants.
+    scores = _fetch(
+        {
+            "scores": [
+                {"uid": 12, "weight": 0.5, "mean_crps": 0.0},
+                {"uid": 13, "weight": 0.5, "mean_crps": 22.0},
+                {"uid": 14, "weight": 0.5, "mean_crps": -1.0},
+                {"uid": 15, "weight": 0.5, "mean_crps": 25.5},
+            ]
+        }
+    )
+    assert scores == {13: 22.0, 15: 25.5}
+
+
+def test_steady_state_field_is_accepted():
+    # The shape the guard must NOT reject: a handful of scored uids, the rest
+    # at weight 0.
+    participants = {3, 17, 41, 68, 90, 114, 137, 160, 191}
+    payload = {
+        "scores": [
+            {
+                "uid": uid,
+                "weight": 0.11 if uid in participants else 0.0,
+                "mean_crps": 0.4 if uid in participants else 0.0,
+            }
+            for uid in range(256)
+        ]
+    }
+    scores = _fetch(payload)
+    assert scores is not None
+    assert set(scores) == participants
+
+
 @pytest.mark.parametrize(
     "payload",
     [
@@ -101,6 +156,7 @@ def test_malformed_row_is_dropped():
         {},
         {"scores": [{"uid": 12, "weight": 0.0, "mean_crps": 0.0}]},
         {"scores": [{"uid": 12, "weight": 0.5, "mean_crps": None}]},
+        {"scores": [{"uid": 12, "weight": 0.5, "mean_crps": 0.0}]},
     ],
 )
 def test_returns_none_when_nothing_usable(payload):

--- a/tests/test_vhft_score_provider.py
+++ b/tests/test_vhft_score_provider.py
@@ -129,9 +129,13 @@ def test_zero_is_kept_as_the_winner_and_negative_is_dropped():
     scores = _fetch(
         {
             "scores": [
-                {"uid": 12, "weight": 0.5, "mean_crps": 0.0},   # winner — kept
+                {"uid": 12, "weight": 0.5, "mean_crps": 0.0},  # winner — kept
                 {"uid": 13, "weight": 0.5, "mean_crps": 22.0},
-                {"uid": 14, "weight": 0.5, "mean_crps": -1.0},  # impossible — dropped
+                {
+                    "uid": 14,
+                    "weight": 0.5,
+                    "mean_crps": -1.0,
+                },  # impossible — dropped
                 {"uid": 15, "weight": 0.5, "mean_crps": 25.5},
             ]
         }
@@ -164,7 +168,9 @@ def test_single_scored_uid_is_not_treated_as_degenerate():
     Whether one participant is enough is compute_vhft_smoothed_score's call
     (VHFT_MIN_PARTICIPANTS), not this parser's.
     """
-    assert _fetch({"scores": [{"uid": 12, "weight": 1.0, "mean_crps": 0.0}]}) == {12: 0.0}
+    assert _fetch(
+        {"scores": [{"uid": 12, "weight": 1.0, "mean_crps": 0.0}]}
+    ) == {12: 0.0}
 
 
 def test_steady_state_field_is_accepted():
@@ -178,7 +184,9 @@ def test_steady_state_field_is_accepted():
                 "weight": 0.11 if uid in participants else 0.0,
                 # Distinct per uid: a real field-relative field is never all-equal,
                 # and an all-equal one is deliberately rejected as a placeholder.
-                "mean_crps": (0.4 + uid / 1000) if uid in participants else 0.0,
+                "mean_crps": (
+                    (0.4 + uid / 1000) if uid in participants else 0.0
+                ),
             }
             for uid in range(256)
         ]

--- a/tests/test_vhft_score_provider.py
+++ b/tests/test_vhft_score_provider.py
@@ -1,9 +1,10 @@
 """Unit tests for vhft_score_provider.py — no DB or network required.
 
-Covers the /v1/scores parsing contract: only rows with positive weight AND
-positive mean_crps are kept, a null mean_crps is dropped rather than coerced,
-and every failure mode returns None so the scoring cycle skips VHFT instead of
-raising.
+Covers the /v1/scores parsing contract: only rows with positive weight are kept
+(scores are field-relative, so 0.0 is a legitimate winning score and must NOT be
+filtered), a null or negative mean_crps is dropped rather than coerced, an
+all-identical field is rejected as a placeholder snapshot, and every failure mode
+returns None so the scoring cycle skips VHFT instead of raising.
 """
 
 from unittest.mock import MagicMock, patch
@@ -104,6 +105,10 @@ def test_bootstrap_snapshot_is_rejected():
     weight alone let all of them through, and 0.0 is the *best* possible value
     to the lower-is-better softmax, so the VHFT block's whole share of emissions
     would be spread across every registered miner — none of whom competed.
+
+    Now caught by the degenerate-snapshot guard (all scores identical) rather than
+    by rejecting 0.0, which is a legitimate winning score under field-relative
+    scoring. VHFT_MAX_PARTICIPANTS=64 backs this up for the 256-uid case.
     """
     bootstrap = {
         "scores": [
@@ -114,20 +119,52 @@ def test_bootstrap_snapshot_is_rejected():
     assert _fetch(bootstrap) is None
 
 
-def test_zero_crps_row_is_dropped_but_healthy_peers_survive():
-    # A partial bootstrap/degraded snapshot must not poison the whole cycle:
-    # drop only the 0.0 rows and keep scoring the real participants.
+def test_zero_is_kept_as_the_winner_and_negative_is_dropped():
+    """0.0 is the BEST field-relative score, not a bootstrap artifact.
+
+    Scores are now relative to each prompt's winner, so the best miner in the
+    window legitimately averages 0.0. Dropping it (the old rule) would exclude
+    the winner from every cycle. A negative score is still impossible and dropped.
+    """
     scores = _fetch(
         {
             "scores": [
-                {"uid": 12, "weight": 0.5, "mean_crps": 0.0},
+                {"uid": 12, "weight": 0.5, "mean_crps": 0.0},   # winner — kept
                 {"uid": 13, "weight": 0.5, "mean_crps": 22.0},
-                {"uid": 14, "weight": 0.5, "mean_crps": -1.0},
+                {"uid": 14, "weight": 0.5, "mean_crps": -1.0},  # impossible — dropped
                 {"uid": 15, "weight": 0.5, "mean_crps": 25.5},
             ]
         }
     )
-    assert scores == {13: 22.0, 15: 25.5}
+    assert scores == {12: 0.0, 13: 22.0, 15: 25.5}
+
+
+def test_identical_nonzero_field_is_rejected_as_a_placeholder():
+    """The degenerate-snapshot guard is not specific to 0.0.
+
+    A real 24h field-relative field is never all-equal, so an identical field at
+    ANY value is a placeholder/degraded snapshot rather than a result.
+    """
+    assert (
+        _fetch(
+            {
+                "scores": [
+                    {"uid": uid, "weight": 0.25, "mean_crps": 7.5}
+                    for uid in (12, 13, 14, 15)
+                ]
+            }
+        )
+        is None
+    )
+
+
+def test_single_scored_uid_is_not_treated_as_degenerate():
+    """A one-miner field is trivially 'all identical' — the guard needs >1 to fire.
+
+    Whether one participant is enough is compute_vhft_smoothed_score's call
+    (VHFT_MIN_PARTICIPANTS), not this parser's.
+    """
+    assert _fetch({"scores": [{"uid": 12, "weight": 1.0, "mean_crps": 0.0}]}) == {12: 0.0}
 
 
 def test_steady_state_field_is_accepted():
@@ -139,7 +176,9 @@ def test_steady_state_field_is_accepted():
             {
                 "uid": uid,
                 "weight": 0.11 if uid in participants else 0.0,
-                "mean_crps": 0.4 if uid in participants else 0.0,
+                # Distinct per uid: a real field-relative field is never all-equal,
+                # and an all-equal one is deliberately rejected as a placeholder.
+                "mean_crps": (0.4 + uid / 1000) if uid in participants else 0.0,
             }
             for uid in range(256)
         ]
@@ -156,7 +195,9 @@ def test_steady_state_field_is_accepted():
         {},
         {"scores": [{"uid": 12, "weight": 0.0, "mean_crps": 0.0}]},
         {"scores": [{"uid": 12, "weight": 0.5, "mean_crps": None}]},
-        {"scores": [{"uid": 12, "weight": 0.5, "mean_crps": 0.0}]},
+        # A negative score is impossible by construction and still unusable. (0.0 is
+        # NOT here any more: under field-relative scoring it is the winning score.)
+        {"scores": [{"uid": 12, "weight": 0.5, "mean_crps": -1.0}]},
     ],
 )
 def test_returns_none_when_nothing_usable(payload):

--- a/tests/test_vhft_score_provider.py
+++ b/tests/test_vhft_score_provider.py
@@ -1,0 +1,116 @@
+"""Unit tests for vhft_score_provider.py — no DB or network required.
+
+Covers the /v1/scores parsing contract: only positive-weight rows are kept, a
+null mean_crps is dropped rather than coerced, and every failure mode returns
+None so the scoring cycle skips VHFT instead of raising.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synth.validator.vhft_score_provider import VhftScoreProvider
+
+
+def _response(payload):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = payload
+    return resp
+
+
+def _fetch(payload):
+    with patch(
+        "synth.validator.vhft_score_provider.requests.get",
+        return_value=_response(payload),
+    ):
+        return VhftScoreProvider(url="http://vhft/v1/scores").fetch_scores()
+
+
+def test_from_env_disabled_when_unset(monkeypatch):
+    monkeypatch.delenv("VHFT_SCORES_URL", raising=False)
+    assert VhftScoreProvider.from_env() is None
+
+
+def test_from_env_enabled_when_set(monkeypatch):
+    monkeypatch.setenv("VHFT_SCORES_URL", "http://vhft/v1/scores")
+    provider = VhftScoreProvider.from_env()
+    assert provider is not None
+    assert provider._url == "http://vhft/v1/scores"
+
+
+def test_keeps_only_positive_weight_rows():
+    # Non-participants come back as weight=0.0/mean_crps=0.0; keeping them would
+    # read as a perfect score to the lower-is-better softmax downstream.
+    scores = _fetch(
+        {
+            "scores": [
+                {"uid": 12, "weight": 0.5, "mean_crps": 22.0},
+                {"uid": 13, "weight": 0.0, "mean_crps": 0.0},
+                {"uid": 14, "weight": 0.5, "mean_crps": 25.5},
+            ]
+        }
+    )
+    assert scores == {12: 22.0, 14: 25.5}
+
+
+def test_null_mean_crps_is_dropped_not_coerced():
+    # Regression: float(None) used to raise TypeError outside the try block,
+    # crashing the scoring cycle instead of skipping VHFT. null is the scorer's
+    # deliberate "no CRPS" sentinel (0.0 is a real perfect score).
+    scores = _fetch(
+        {
+            "scores": [
+                {"uid": 12, "weight": 0.5, "mean_crps": None},
+                {"uid": 14, "weight": 0.5, "mean_crps": 25.5},
+            ]
+        }
+    )
+    assert scores == {14: 25.5}
+
+
+def test_null_weight_is_dropped_not_coerced():
+    scores = _fetch(
+        {
+            "scores": [
+                {"uid": 12, "weight": None, "mean_crps": 22.0},
+                {"uid": 14, "weight": 0.5, "mean_crps": 25.5},
+            ]
+        }
+    )
+    assert scores == {14: 25.5}
+
+
+def test_malformed_row_is_dropped():
+    scores = _fetch(
+        {
+            "scores": [
+                {"weight": 0.5, "mean_crps": 22.0},  # no uid
+                {"uid": "not-an-int", "weight": 0.5, "mean_crps": 22.0},
+                {"uid": 14, "weight": 0.5, "mean_crps": 25.5},
+            ]
+        }
+    )
+    assert scores == {14: 25.5}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"scores": []},
+        {},
+        {"scores": [{"uid": 12, "weight": 0.0, "mean_crps": 0.0}]},
+        {"scores": [{"uid": 12, "weight": 0.5, "mean_crps": None}]},
+    ],
+)
+def test_returns_none_when_nothing_usable(payload):
+    assert _fetch(payload) is None
+
+
+def test_returns_none_on_http_failure():
+    with patch(
+        "synth.validator.vhft_score_provider.requests.get",
+        side_effect=Exception("connection refused"),
+    ):
+        provider = VhftScoreProvider(url="http://vhft/v1/scores")
+        assert provider.fetch_scores() is None

--- a/uv.lock
+++ b/uv.lock
@@ -3323,11 +3323,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "84.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73", size = 1168449, upload-time = "2026-08-08T18:27:58.365Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670", size = 818216, upload-time = "2026-08-08T18:27:56.719Z" },
 ]
 
 [[package]]
@@ -3486,7 +3486,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "requests", specifier = ">=2" },
     { name = "rich", specifier = ">=13" },
-    { name = "setuptools", specifier = ">=68" },
+    { name = "setuptools", specifier = ">=83.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.36" },
     { name = "starlette", specifier = ">=0.37.2" },
     { name = "tenacity", specifier = "==9.0.0" },


### PR DESCRIPTION
Adds the 10s VHFT (Synth Ultra) competition to the reward blend. The validator
pulls external per-uid scores each cycle (VHFT_SCORES_URL) and runs them through
the same shape/softmax/blend path as the other three competitions.

Draft — inert until VHFT_SCORES_URL is set. Open TODOs: calibrate softmax_beta +
window_days for the mean_crps scale; confirm the participant-share distribution;
add hotkey to the scores endpoint for re-registration robustness.